### PR TITLE
Centralize selection of a user's profile image URL

### DIFF
--- a/common/util/index.js
+++ b/common/util/index.js
@@ -83,3 +83,8 @@ export function buildURL(baseURL, queryArgs) {
   const search = queryStr ? `?${queryStr}` : ''
   return `${baseURL}${search}`
 }
+
+export function getUserProfileUrl(user) {
+  const githubPhotos = (((user || {}).authProviderProfiles || {}).githubOAuth2 || {}).photos
+  return githubPhotos && githubPhotos.length ? githubPhotos[0].value : null
+}

--- a/server/graphql/models/User/schema.js
+++ b/server/graphql/models/User/schema.js
@@ -31,6 +31,7 @@ export const User = new GraphQLObjectType({
     email: {type: new GraphQLNonNull(GraphQLEmail), description: 'The user email'},
     emails: {type: new GraphQLNonNull(new GraphQLList(GraphQLEmail)), description: 'The user emails'},
     handle: {type: new GraphQLNonNull(GraphQLString), description: 'The user handle'},
+    profileUrl: {type: GraphQLString, description: 'The user profile image URL'},
     name: {type: new GraphQLNonNull(GraphQLString), description: 'The user name'},
     phone: {type: GraphQLPhoneNumber, description: 'The user phone number'},
     dateOfBirth: {type: GraphQLDateTime, description: "The user's date of birth"},


### PR DESCRIPTION
Makes an attempt to auto-parse a user's profile image URL and attaches as `profileUrl` prop. We now have at least 2 different places where user avatars need to be displayed: echo chat and in parts of the retrospective survey form. Ideally, we've only got code written once to determine the URL for a profile image to be displayed. Seems to make the most sense that this logic lives here in the `idm` service.
