### PR TITLE
ensure webpack failures fail deploy

### DIFF
--- a/config/webpack.js
+++ b/config/webpack.js
@@ -2,6 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const WebpackFailPlugin = require('webpack-fail-plugin')
 
 const config = require('./index')
 
@@ -53,6 +54,7 @@ const resolve = {
 
 /** plugins */
 const plugins = [
+  WebpackFailPlugin,
   new webpack.DefinePlugin({
     'process.env': {
       // useful to reduce the size of client-side libraries, e.g. react

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
     "webpack-dev-middleware": "^1.6.1",
+    "webpack-fail-plugin": "^1.0.5",
     "webpack-hot-middleware": "^2.10.0",
     "yamljs": "^0.2.5"
   },


### PR DESCRIPTION
Fixes #132. By default, Webpack doesn't fail if an error occurs -- it returns exit code == 0. Adding a plugin fixes it. File under #WTF!
