### PR TITLE
Minor tweaks for embedding profile form

### DIFF
--- a/common/components/Home/index.jsx
+++ b/common/components/Home/index.jsx
@@ -19,11 +19,6 @@ export default class Home extends Component {
             onClick={this.props.onEditProfile}
             />
           <ListItem
-            caption="Explore API"
-            leftIcon="flash_on"
-            onClick={this.props.onGraphiQL}
-            />
-          <ListItem
             caption="Sign Out"
             leftIcon="subdirectory_arrow_left"
             onClick={this.props.onSignOut}
@@ -36,6 +31,5 @@ export default class Home extends Component {
 
 Home.propTypes = {
   onEditProfile: PropTypes.func.isRequired,
-  onGraphiQL: PropTypes.func.isRequired,
   onSignOut: PropTypes.func.isRequired,
 }

--- a/common/components/Profile/index.css
+++ b/common/components/Profile/index.css
@@ -1,7 +1,7 @@
 .card {
-  margin-top: 5rem;
+  margin-top: 2rem;
 }
 
 .cardContent {
-  padding: 2rem;
+  margin: 2rem;
 }

--- a/common/components/Profile/index.jsx
+++ b/common/components/Profile/index.jsx
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import {Card, CardTitle} from 'react-toolbox/lib/card'
+import {CardTitle} from 'react-toolbox/lib/card'
 
 // FIXME: "dumb" components shouldn't import containers
 import UserForm from 'src/common/containers/UserForm'
@@ -9,12 +9,12 @@ import styles from './index.css'
 export default class Profile extends Component {
   render() {
     return (
-      <Card className={styles.card}>
+      <div className={styles.card}>
         <CardTitle title="Edit Profile"/>
         <div className={styles.cardContent}>
           <UserForm buttonLabel="Save"/>
         </div>
-      </Card>
+      </div>
     )
   }
 }

--- a/common/containers/Home/index.jsx
+++ b/common/containers/Home/index.jsx
@@ -10,18 +10,11 @@ export class Home extends Component {
   constructor(props) {
     super(props)
     this.handleEditProfile = this.handleEditProfile.bind(this)
-    this.handleGraphiQL = this.handleGraphiQL.bind(this)
     this.handleSignOut = this.handleSignOut.bind(this)
   }
 
   handleEditProfile() {
     this.props.dispatch(push('/profile'))
-  }
-
-  handleGraphiQL() {
-    if (__CLIENT__) {
-      window.location.href = process.env.GRAPHIQL_BASE_URL
-    }
   }
 
   handleSignOut() {
@@ -32,7 +25,7 @@ export class Home extends Component {
 
   render() {
     return (
-      <HomeComponent onEditProfile={this.handleEditProfile} onGraphiQL={this.handleGraphiQL} onSignOut={this.handleSignOut}/>
+      <HomeComponent onEditProfile={this.handleEditProfile} onSignOut={this.handleSignOut}/>
     )
   }
 }


### PR DESCRIPTION
## Overview

The `idm` UI code needs a serious overhaul, but for now, these minor tweaks remove some of the wonky card wrapping from `react-toolbox` and slightly simplifies the UI of the profile form view, making it more suitable for embedding elsewhere (e.g. in the `game` UI)

Changes:
- removes "Explore API" item from home menu, to be reintroduced differently if ever desired
- makes minor adjustment to styling of `Profile` component/view

## Data Model / DB Schema Changes
None.

## Environment / Configuration Changes
None.
