### PR TITLE
Use *new* color logo instead of old B&W one

### DIFF
--- a/common/components/SignIn/index.jsx
+++ b/common/components/SignIn/index.jsx
@@ -35,7 +35,7 @@ export default class SignIn extends Component {
     return (
       <Card className={styles.card}>
         <div className={styles.cardContent}>
-          <img className={styles.lgLogo} src="https://brand.learnersguild.org/assets/learners-guild-logo-black-250x149.png"/>
+          <img className={styles.lgLogo} src="https://brand.learnersguild.org/assets/learners-guild-logo-color-250x149.png"/>
         </div>
         {authActions}
       </Card>

--- a/common/components/SignUp/index.jsx
+++ b/common/components/SignUp/index.jsx
@@ -135,7 +135,7 @@ class SignUp extends Component {
     return (
       <Card className={styles.card}>
         <div className={styles.cardContent}>
-          <img className={styles.lgLogo} src="https://brand.learnersguild.org/assets/learners-guild-logo-black-250x149.png"/>
+          <img className={styles.lgLogo} src="https://brand.learnersguild.org/assets/learners-guild-logo-color-250x149.png"/>
           {cardContent}
         </div>
       </Card>


### PR DESCRIPTION
**DO NOT MERGE** until https://github.com/LearnersGuild/brand/pull/1 is merged. There is no color logo yet served by brand, so this will fail.

Use the new and pretty logo!

![learners-guild-logo-color-250x149](https://cloud.githubusercontent.com/assets/709100/21698593/afb51384-d365-11e6-83cc-ca8aac95da61.png)