### PR TITLE
change app theme colors to match LG brand color palette

### DIFF
--- a/common/theme.scss
+++ b/common/theme.scss
@@ -1,6 +1,3 @@
-// $color-primary: $palette-indigo-500 !default;
-// $color-primary-dark: $palette-indigo-700 !default;
-// $color-accent: $palette-pink-a200 !default;
-// $color-accent-dark: $palette-pink-700 !default;
-// $color-primary-contrast: $color-dark-contrast !default;
-// $color-accent-contrast: $color-dark-contrast !default;
+$color-primary: #00A3DF;
+$color-primary-dark: #00A3DF;
+$input-text-error-color: #00A3DF;


### PR DESCRIPTION
Fixes [story 92](https://app.clubhouse.io/learnersguild/story/92/use-on-brand-colors-where-possible).

## Overview

Change app theme colors to match LG brand color palette

## Data Model / DB Schema Changes

## Environment / Configuration Changes

## Notes
