### PR TITLE
Bugfix: port removed from config/development.js

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -1,7 +1,6 @@
 module.exports = {
   server: {
     secure: false,
-    port: 9001,
     rethinkdb: {
       url: process.env.RETHINKDB_URL || 'rethinkdb://localhost:28015/idm_development',
     },


### PR DESCRIPTION
[No Issue]

## Overview
Port is now correctly read from process.env in the development environment.

## Environment / Configuration Changes
Removes a line from config/development.js that was setting the port to 9001 instead of using the env.
