### PR TITLE
deactivateUser and reactivateUser mutations

### DIFF
--- a/server/actions/deactivateUser.js
+++ b/server/actions/deactivateUser.js
@@ -1,0 +1,10 @@
+import {connect} from 'src/db'
+
+const r = connect()
+
+export default async function deactivateUser(id) {
+  return r.table('users')
+    .get(id)
+    .update({active: false, updatedAt: r.now()}, {returnChanges: 'always'})
+    .run()
+}

--- a/server/actions/reactivateUser.js
+++ b/server/actions/reactivateUser.js
@@ -1,0 +1,10 @@
+import {connect} from 'src/db'
+
+const r = connect()
+
+export default async function reactivateUser(id) {
+  return r.table('users')
+    .get(id)
+    .update({active: true, updatedAt: r.now()}, {returnChanges: true})
+    .run()
+}


### PR DESCRIPTION
Fixes [ch926](https://app.clubhouse.io/learnersguild/story/926/moderators-can-deactivate-players)

## Overview
* Adds server actions called `deactivateUser` and `reactivateUser` which mutate the user in the database
* Adds `deactivateUser` to the graphql API 
* Validates that the user performing the action is authorized before performing the mutation

## Data Model / DB Schema Changes

## Environment / Configuration Changes

## Notes
