### PR TITLE
better naming of graphql transactions in newrelic

### DIFF
--- a/server/graphql/rootMutation.js
+++ b/server/graphql/rootMutation.js
@@ -1,4 +1,5 @@
 import {GraphQLObjectType} from 'graphql'
+import {instrumentResolvers} from './util'
 
 import user from './models/User/mutation'
 import inviteCode from './models/InviteCode/mutation'
@@ -7,5 +8,5 @@ const rootFields = Object.assign(user, inviteCode)
 
 export default new GraphQLObjectType({
   name: 'RootMutation',
-  fields: () => rootFields
+  fields: instrumentResolvers(rootFields, 'mutation'),
 })

--- a/server/graphql/rootQuery.js
+++ b/server/graphql/rootQuery.js
@@ -1,4 +1,5 @@
 import {GraphQLObjectType} from 'graphql'
+import {instrumentResolvers} from './util'
 
 import user from './models/User/query'
 import inviteCode from './models/InviteCode/query'
@@ -7,5 +8,5 @@ const rootFields = Object.assign(user, inviteCode)
 
 export default new GraphQLObjectType({
   name: 'RootQuery',
-  fields: () => rootFields
+  fields: instrumentResolvers(rootFields, 'query'),
 })

--- a/server/graphql/util/index.js
+++ b/server/graphql/util/index.js
@@ -1,6 +1,23 @@
 import {GraphQLError} from 'graphql/error'
+import newrelic from 'newrelic'
 
 export const errors = {
   notAuthorized: () => (new GraphQLError('You are not authorized to do that.')),
   notFound: type => (new GraphQLError(`${type || 'Item'} not found`)),
+}
+
+export function instrumentResolvers(fields, prefix) {
+  return Object.keys(fields).map(queryName => {
+    const schema = fields[queryName]
+    const originalResolver = schema.resolve
+    return {
+      [queryName]: {
+        ...schema,
+        resolve: (...args) => {
+          newrelic.setTransactionName(`graphql ${prefix} ${queryName}`)
+          return originalResolver(...args)
+        }
+      }
+    }
+  }).reduce((result, next) => ({...result, ...next}), {})
 }


### PR DESCRIPTION
## Overview 
All graphql requests look the same in newrelic, so when we have
performance issues it's hard to tell which requests are taking the most
time. This PR changes the way transactions are named in newrelic so that
they include the query or mutation name.

### Before:
![transactions_-_game_-_new_relic](https://cloud.githubusercontent.com/assets/189699/24760218/02657280-1ab6-11e7-8439-7d5fd1b63767.png)

### After:
![transactions_-_game_-_new_relic](https://cloud.githubusercontent.com/assets/189699/24761182/a5b0b376-1ab8-11e7-9375-6f3df9f45b3a.png)