### PR TITLE
Full name required to be two words

### DIFF
--- a/common/containers/UserForm/index.jsx
+++ b/common/containers/UserForm/index.jsx
@@ -7,7 +7,7 @@ import UserFormComponent from 'src/common/components/UserForm'
 
 function validate({name, phone, dateOfBirth, timezone}) {
   const errors = {}
-  if (!name || !name.match(/\w{3,}/)) {
+  if (!name || !name.match(/\w{2,} \w{2,}/)) {
     errors.name = 'Please use your full, legal name'
   }
   if (!phone || phone.length < 10) {


### PR DESCRIPTION
# Fixes Story 2099
https://app.clubhouse.io/learnersguild/story/2099/players-should-be-required-to-have-a-name-with-at-least-two-words-representing-first-and-last-name

## Overview
Added a check on the user's full name requiring two words separated by spaces.  We also adjusted it so names would be required to be 2 characters long instead of 3 characters long, in case anyone has a very short name.

## Data Model / DB Schema Changes
N/A

## Environment / Configuration Changes
N/A

## Notes
