### PR TITLE
Fix broken user avatars 

### DIFF
--- a/server/auth/__tests__/helpers-test.js
+++ b/server/auth/__tests__/helpers-test.js
@@ -1,7 +1,12 @@
 import test from 'ava'
 import {cloneDeep, merge} from 'lodash'
 
-import {mergeUserInfo} from 'src/server/auth/helpers'
+import {connect} from 'src/db'
+import {resetData, cleanupDB} from 'src/test/db'
+
+import {mergeUserInfo, addUserAvatar} from 'src/server/auth/helpers'
+
+const r = connect()
 
 test('mergeUserInfo doesn\'t overwrite email address', t => {
   const user = {
@@ -22,4 +27,41 @@ test('mergeUserInfo doesn\'t overwrite email address', t => {
 
   t.plan(1)
   t.is(mergedUser.inviteCode, 'oakland123')
+})
+
+test.before(async () => {
+  await resetData()
+})
+
+test.after(async () => {
+  await cleanupDB()
+})
+
+test('addUserAvatar: adds user\'s github avatar on sign-up', async t => {
+  const jpegDataURL = 'https://www.learnersguild.org/images/LogoPrimary.png'
+  const user = {
+    id: '06f211e3-bd02-4fbd-b977-dc5e769ad092',
+    authProviderProfiles: {
+      githubOAuth2: {
+        photos: [
+          {
+            value: jpegDataURL
+          }
+        ]
+      }
+    }
+  }
+
+  const result = await addUserAvatar(user)
+
+  const userAvatar = await r.table('userAvatars')
+    .filter({id: user.id})
+    .nth(0)
+
+  t.plan(5)
+  t.is(result.inserted, 1, 'should insert one row')
+  t.is(userAvatar.id, user.id, 'avatar id should match user')
+  t.not(userAvatar.jpegData, null, 'should insert jpeg data')
+  t.not(userAvatar.createdAt, null, 'should set createdAt date')
+  t.not(userAvatar.updatedAt, null, 'should set updatedAt date')
 })

--- a/server/auth/__tests__/helpers-test.js
+++ b/server/auth/__tests__/helpers-test.js
@@ -4,7 +4,7 @@ import {cloneDeep, merge} from 'lodash'
 import {connect} from 'src/db'
 import {resetData, cleanupDB} from 'src/test/db'
 
-import {mergeUserInfo, addUserAvatar} from 'src/server/auth/helpers'
+import {mergeUserInfo, saveUserAvatar} from 'src/server/auth/helpers'
 
 const r = connect()
 
@@ -37,7 +37,7 @@ test.after(async () => {
   await cleanupDB()
 })
 
-test('addUserAvatar: adds user\'s github avatar on sign-up', async t => {
+test('saveUserAvatar: saves user\'s github avatar on sign-up', async t => {
   const jpegDataURL = 'https://www.learnersguild.org/images/LogoPrimary.png'
   const user = {
     id: '06f211e3-bd02-4fbd-b977-dc5e769ad092',
@@ -52,7 +52,7 @@ test('addUserAvatar: adds user\'s github avatar on sign-up', async t => {
     }
   }
 
-  const result = await addUserAvatar(user)
+  const result = await saveUserAvatar(user)
 
   const userAvatar = await r.table('userAvatars')
     .filter({id: user.id})

--- a/server/auth/github.js
+++ b/server/auth/github.js
@@ -13,6 +13,7 @@ import {
   getUserByGithubId,
   getInviteCodesByCode,
   defaultSuccessRedirect,
+  addUserAvatar,
 } from './helpers'
 
 const config = require('src/config')
@@ -73,6 +74,9 @@ async function createOrUpdateUserFromGitHub(req, accessToken, refreshToken, prof
     const userInfo = githubProfileToUserInfo(accessToken, refreshToken, profile, primaryEmail, emails, inviteCode)
     const result = await createOrUpdateUser(user, userInfo)
     user = (result.inserted || result.replaced) ? result.changes[0].new_val : user
+    if (result.inserted) {
+      await addUserAvatar(user)
+    }
     cb(null, user)
   } catch (err) {
     sentry.captureException(err)

--- a/server/auth/github.js
+++ b/server/auth/github.js
@@ -13,7 +13,7 @@ import {
   getUserByGithubId,
   getInviteCodesByCode,
   defaultSuccessRedirect,
-  addUserAvatar,
+  saveUserAvatar,
 } from './helpers'
 
 const config = require('src/config')
@@ -75,7 +75,7 @@ async function createOrUpdateUserFromGitHub(req, accessToken, refreshToken, prof
     const result = await createOrUpdateUser(user, userInfo)
     user = (result.inserted || result.replaced) ? result.changes[0].new_val : user
     if (result.inserted) {
-      await addUserAvatar(user)
+      await saveUserAvatar(user)
     }
     cb(null, user)
   } catch (err) {

--- a/server/auth/helpers.js
+++ b/server/auth/helpers.js
@@ -12,7 +12,7 @@ export function mergeUserInfo(user, userInfo) {
   return merge(user, userInfo, {inviteCode, email, name, roles, createdAt, active, id})
 }
 
-export function addUserAvatar(user) {
+export function saveUserAvatar(user) {
   const githubProfilePhotos = (user.authProviderProfiles.githubOAuth2 || {}).photos || []
   const githubProfilePhotoURL = (githubProfilePhotos[0] || {}).value
   return r.table('userAvatars')

--- a/server/auth/helpers.js
+++ b/server/auth/helpers.js
@@ -12,6 +12,19 @@ export function mergeUserInfo(user, userInfo) {
   return merge(user, userInfo, {inviteCode, email, name, roles, createdAt, active, id})
 }
 
+export function addUserAvatar(user) {
+  const githubProfilePhotos = (user.authProviderProfiles.githubOAuth2 || {}).photos || []
+  const githubProfilePhotoURL = (githubProfilePhotos[0] || {}).value
+  return r.table('userAvatars')
+    .insert({
+      id: user.id,
+      jpegData: r.http(githubProfilePhotoURL, {resultFormat: 'binary'})
+        .default(null),
+      createdAt: r.now(),
+      updatedAt: r.now(),
+    }, {returnChanges: true})
+}
+
 export function createOrUpdateUser(user, userInfo) {
   const timestamps = {updatedAt: r.now()}
   if (user) {

--- a/server/avatars.js
+++ b/server/avatars.js
@@ -14,7 +14,10 @@ app.get('/:filename', (req, res) => {
     .run()
     .then(userAvatar => {
       if (!userAvatar) {
-        res.status(404).send(`No such image: ${filename}`)
+        const notFoundAvatarURL = 'https://brand.learnersguild.org/assets/echo-icon-128x128.png'
+        res
+          .status(307)
+          .redirect(notFoundAvatarURL)
         return
       }
 


### PR DESCRIPTION
Fixes [#1003](https://github.com/LearnersGuild/echo/issues/1003) (issue is in echo)

## Overview

- Added a helper function saveUserAvatar that copies the user's avatar from Github to the database on sign up. 
- - Created tests for the helper function.

- When an avatar is not found, it will redirect to the default one with a 307 temporary redirect code.

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

None

## Notes

None
