### PR TITLE
Replace all references to 'backoffice' with 'admin'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ db/database.json
 .flooignore
 *.env
 LearnersGuild-idm.aes
+rethinkdb_data/*

--- a/server/graphql/models/InviteCode/__tests__/mutation-test.js
+++ b/server/graphql/models/InviteCode/__tests__/mutation-test.js
@@ -14,7 +14,7 @@ const inputInviteCode = {
   description: 'whee',
   roles: ['role1', 'role2'],
 }
-const backofficeUser = {id: 'me', handle: 'me', roles: ['backoffice']}
+const admin = {id: 'me', handle: 'me', roles: ['admin']}
 test.before(async () => {
   await resetData()
 })
@@ -30,7 +30,7 @@ test('createInviteCode: creates the invite code correctly', async t => {
     mutation,
     api,
     {inviteCode: inputInviteCode},
-    {currentUser: backofficeUser}
+    {currentUser: admin}
   )
   const savedInviteCode = await r.table('inviteCodes').getAll(inputInviteCode.code, {index: 'code'}).nth(0)
 
@@ -46,7 +46,7 @@ test('createInviteCode: defaults active to true and permanent to false', async t
     mutation,
     api,
     {inviteCode: inputInviteCode},
-    {currentUser: backofficeUser}
+    {currentUser: admin}
   )
   const savedInviteCode = await r.table('inviteCodes').getAll(inputInviteCode.code, {index: 'code'}).nth(0)
 

--- a/server/graphql/models/InviteCode/mutation.js
+++ b/server/graphql/models/InviteCode/mutation.js
@@ -27,8 +27,8 @@ export default {
     },
     async resolve(source, {inviteCode}, {rootValue: {currentUser}}) {
       try {
-        const currentUserIsBackOffice = (currentUser && currentUser.roles && currentUser.roles.indexOf('backoffice') >= 0)
-        if (!currentUserIsBackOffice) {
+        const currentUserIsAdmin = (currentUser && currentUser.roles && currentUser.roles.indexOf('admin') >= 0)
+        if (!currentUserIsAdmin) {
           throw new GraphQLError('You are not authorized to do that')
         }
 

--- a/server/graphql/models/User/mutation.js
+++ b/server/graphql/models/User/mutation.js
@@ -50,8 +50,8 @@ export default {
       user: {type: new GraphQLNonNull(InputUser)},
     },
     async resolve(source, {user}, {rootValue: {currentUser}}) {
-      const currentUserIsBackOffice = (currentUser && currentUser.roles && currentUser.roles.indexOf('backoffice') >= 0)
-      if (!currentUser || (user.id !== currentUser.id && !currentUserIsBackOffice)) {
+      const currentUserIsAdmin = (currentUser && currentUser.roles && currentUser.roles.indexOf('admin') >= 0)
+      if (!currentUser || (user.id !== currentUser.id && !currentUserIsAdmin)) {
         throw new GraphQLError('You are not authorized to do that.')
       }
 


### PR DESCRIPTION
Fixes # 186

## Overview

Replaced all references to 'backoffice' with 'admin', which is the current name of the role that can perform these actions.

## Data Model / DB Schema Changes

## Environment / Configuration Changes

## Notes

Added rethinkdb_data folder to .gitignore because it just contains a log file and metadata.