### PR TITLE
Filters createUser feed change - fixes #201 #203

### DIFF
--- a/server/configureChangeFeeds/userCreated.js
+++ b/server/configureChangeFeeds/userCreated.js
@@ -18,7 +18,6 @@ export default function userCreated(queueService) {
 
 function _getFeed() {
   return r.table('users')
-    .getAll(USER_ROLES.LEARNER, {index: 'roles'})
     .changes()
     .filter(r.row('old_val').eq(null))
 }


### PR DESCRIPTION
Fixes #201, #203

## Overview

userCreated worker queue was receiving queue elements upon updating a user - this lead to a big bug where everyone who had their role changed from 'member' to 'learner' fired off workers.

1. We don't want to trigger workers on updates, only on creation / insert.
1. We don't care about filtering for 'learner' roles only, but rather want to fire off workers for any creation at all. 

Solution: By removing the `getAll` token the filter for `old_val` now functions properly (is not null when updating, but is null when newly created) allowing us to only trigger workers when creating new users.

## Data Model / DB Schema Changes
None

## Environment / Configuration Changes
None

## Notes