### PR TITLE
modifies graphql InputUser type to accomodate updating user roles from echo

### DIFF
--- a/common/actions/updateUser.js
+++ b/common/actions/updateUser.js
@@ -17,7 +17,7 @@ function updateUserFailure(error) {
   return {type: UPDATE_USER_FAILURE, error}
 }
 
-export default function updateUser(userData, redirectLocation, responseType) {
+export default function updateUser(userValues, redirectLocation, responseType) {
   return (dispatch, getState) => {
     dispatch(updateUserRequest())
 
@@ -43,7 +43,7 @@ mutation ($user: InputUser!) {
 }
       `,
       variables: {
-        user: userData,
+        user: _getInputUserFields(userValues),
       },
     }
     const {auth} = getState()
@@ -61,4 +61,9 @@ mutation ($user: InputUser!) {
         dispatch(updateUserFailure(error))
       })
   }
+}
+
+function _getInputUserFields(values) {
+  const {id, email, name, phone, dateOfBirth, timezone} = values || {}
+  return {id, email, name, phone, dateOfBirth, timezone}
 }

--- a/common/actions/updateUser.js
+++ b/common/actions/updateUser.js
@@ -33,12 +33,6 @@ mutation ($user: InputUser!) {
     phone
     dateOfBirth
     timezone
-    roles
-    authProviders {
-      githubOAuth2 {
-        accessToken
-      }
-    }
   }
 }
       `,

--- a/common/util/userCan.js
+++ b/common/util/userCan.js
@@ -14,6 +14,7 @@ const CAPABILITY_ROLES = {
   deactivateUser: [ADMIN],
   reactivateUser: [ADMIN],
   updateUser: [ADMIN],
+  updateUserRoles: [ADMIN],
   viewAllUsers: [ADMIN],
   viewOwnProfile: GENERAL_USE,
   viewHome: GENERAL_USE,

--- a/server/graphql/mutations/updateUser.js
+++ b/server/graphql/mutations/updateUser.js
@@ -12,16 +12,20 @@ export default {
     user: {type: new GraphQLNonNull(InputUser)},
   },
   async resolve(source, {user}, {rootValue: {currentUser}}) {
-    if (!userCan(currentUser, 'updateUser') && user.id !== currentUser.id) {
+    if (user.id !== currentUser.id && !userCan(currentUser, 'updateUser')) {
       throw new GraphQLError('You are not authorized to do that.')
+    }
+    if (user.roles && !userCan(currentUser, 'updateUserRoles')) {
+      throw new GraphQLError('You are not authorized to edit user roles')
     }
 
     try {
       return UserModel
         .get(user.id)
         .updateWithTimestamp(user)
-    } catch (error) {
-      throw new GraphQLError('Could not update user, please try again')
+    } catch (err) {
+      console.error(err)
+      throw new GraphQLError('Could not update user')
     }
   },
 }

--- a/server/graphql/schemas/InputUser.js
+++ b/server/graphql/schemas/InputUser.js
@@ -1,4 +1,4 @@
-import {GraphQLNonNull, GraphQLString, GraphQLID} from 'graphql'
+import {GraphQLNonNull, GraphQLString, GraphQLID, GraphQLList} from 'graphql'
 import {GraphQLInputObjectType} from 'graphql/type'
 import {GraphQLEmail, GraphQLDateTime} from 'graphql-custom-types'
 
@@ -15,5 +15,6 @@ export default new GraphQLInputObjectType({
     phone: {type: GraphQLPhoneNumber, description: 'The user phone number'},
     dateOfBirth: {type: GraphQLDateTime, description: "The user's date of birth"},
     timezone: {type: GraphQLString, description: 'The user timezone'},
+    roles: {type: new GraphQLList(GraphQLString), description: 'The user roles'},
   })
 })

--- a/server/graphql/schemas/InputUser.js
+++ b/server/graphql/schemas/InputUser.js
@@ -10,7 +10,6 @@ export default new GraphQLInputObjectType({
   fields: () => ({
     id: {type: new GraphQLNonNull(GraphQLID), description: 'The user UUID'},
     email: {type: new GraphQLNonNull(GraphQLEmail), description: 'The user email'},
-    handle: {type: new GraphQLNonNull(GraphQLString), description: 'The user handle'},
     name: {type: new GraphQLNonNull(GraphQLString), description: 'The user name'},
     phone: {type: GraphQLPhoneNumber, description: 'The user phone number'},
     dateOfBirth: {type: GraphQLDateTime, description: "The user's date of birth"},

--- a/server/services/dataService/models/user.js
+++ b/server/services/dataService/models/user.js
@@ -1,3 +1,5 @@
+import {USER_ROLES} from 'src/common/models/user'
+
 export default function userModel(thinky) {
   const {r, type: {string, boolean, date, array, object}} = thinky
 
@@ -32,6 +34,7 @@ export default function userModel(thinky) {
       timezone: string(),
 
       roles: array()
+        .schema(string().enum(Object.values(USER_ROLES)))
         .default([]),
 
       inviteCode: string(),


### PR DESCRIPTION
Part of fix for echo issue 1072

## Overview
- adds `role` field to the `InputUser` graphql type

## Data Model / DB Schema Changes
see above

## Environment / Configuration Changes
none
