### PR TITLE
Automates the process of generating and adding JWT keys to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,12 @@ Be sure you've read the [instructions for contributing](./CONTRIBUTING.md).
     - Homepage URL: http://idm.learnersguild.dev
     - Authorization callback URL: http://idm.learnersguild.dev/auth/github/callback
 
-9. Generate a key-pair for JWT token signing / verifying:
-
-    ```bash
-    openssl genrsa -out /tmp/private-key.pem 2048
-    openssl rsa -in /tmp/private-key.pem -outform PEM -pubout -out /tmp/public-key.pem
-    ```
-
-10. Create a free AWS account:
+9. Create a free AWS account:
 [https://aws.amazon.com](https://aws.amazon.com/)
 
 Make a copy of your access key ID and secret access key. You'll need to include these in your  environment variables in the next step.
 
-11. Create your `.env.development` file for your environment. Example:
+10. Create your `.env.development` file for your environment. Example:
 
     ```bash
     PORT=9001
@@ -86,12 +79,16 @@ Make a copy of your access key ID and secret access key. You'll need to include 
     # For JWT string data below, replace all linebreaks with \n
     # and include -----BEGIN RSA PRIVATE KEY----- and -----END RSA PRIVATE KEY-----
     # remove these three commented lines
-    JWT_PRIVATE_KEY="<quoted string data from /tmp/private-key.pem >"
-    JWT_PUBLIC_KEY="<quoted string data from /tmp/public-key.pem replace all linebreaks with \n >"
     S3_BUCKET=guild-development
     S3_KEY_PREFIX=db
     AWS_ACCESS_KEY_ID=<YOUR_AWS_ACCESS_KEY_ID>
     AWS_SECRET_ACCESS_KEY=<YOUR_AWS_SECRET_ACCESS_KEY>
+    ```
+
+11. Generate a key-pair for JWT token signing / verifying:
+
+    ```
+    ./createKeys.sh
     ```
 
 12. Run the setup tasks:

--- a/createKeys.sh
+++ b/createKeys.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+openssl genrsa -out ./private-key.pem 2048
+openssl rsa -in ./private-key.pem -outform PEM -pubout -out ./public-key.pem
+
+[[ $(grep -c "^$" .env.development) < 1 ]] && NEWLINE=$'\r' || NEWLINE=""
+
+read -r -d '' PARSED_PRIVATE << EndOfMessage2
+
+$( echo "$NEWLINE""JWT_PRIVATE_KEY=\"" | tr -d "\n" )$( cat ./private-key.pem | perl -pe 's/\n/\\n/g' | perl -pe 's/\\n$//g' )"
+EndOfMessage2
+
+read -r -d '' PARSED_PUBLIC << EndOfMessage
+$( echo $'\n'"JWT_PUBLIC_KEY=\"" | tr -d "\n" )$( cat ./public-key.pem | perl -pe 's/\n/\\n/g' | perl -pe 's/\\n$//g' )"
+EndOfMessage
+
+echo $PARSED_PRIVATE >> ./.env.development
+echo $PARSED_PUBLIC >> ./.env.development
+
+rm ./public-key.pem
+rm ./private-key.pem


### PR DESCRIPTION
Changes readme to reflect this new method

Fixes No issue

## Overview
By feedback of the onboarding members, too many errors happen around removing the linebreaks and manually replacing them with `\n` characters, so now we just run a script that puts both keys into the `.env.development` file

## Data Model / DB Schema Changes
N/A

## Environment / Configuration Changes
N/A

## Notes

1. Perhaps the name of the script could be better
1. Perhaps the script should be placed in a `/bin/` folder
